### PR TITLE
EUDEV-20371: fixes the vertical positioning of the calendar icons in the date range picker

### DIFF
--- a/daterangepicker.scss
+++ b/daterangepicker.scss
@@ -404,13 +404,9 @@ $daterangepicker-ranges-active-border-radius: $daterangepicker-border-radius !de
     i {
       position: absolute;
 
-      // NOTE: These appear to be eyeballed to me...
       left: 8px;
-      top: 8px;
-
-      &.bi {
-        top: 0;
-      }
+      top: 50%;
+      transform: translateY(-50%);
     }
   }
   &.rtl {


### PR DESCRIPTION
**Description**

This PR fixes the vertical alignment of the calendar icons in the date range picker.

**Ticket(s)**
- [EUDEV-20371](https://vdigital.atlassian.net/browse/EUDEV-20371)

Before:
<img width="565" alt="Screenshot 2023-09-01 at 14 39 58" src="https://github.com/dangrossman/daterangepicker/assets/129767549/c6ff5b28-be75-4ffb-a2dc-d925570038ea">

After:
<img width="564" alt="Screenshot 2023-09-01 at 14 39 39" src="https://github.com/dangrossman/daterangepicker/assets/129767549/9a4ce73e-f773-4b8a-be58-b6a12c877f18">

[EUDEV-20371]: https://vdigital.atlassian.net/browse/EUDEV-20371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ